### PR TITLE
User Entity 및 회원가입 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/with_yu/common/response/error/ErrorType.java
+++ b/src/main/java/with_yu/common/response/error/ErrorType.java
@@ -28,6 +28,13 @@ public enum ErrorType {
     CARPOOL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카풀입니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰입니다."),
 
+    // 충돌
+    // 409
+    USER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
+    EMAIL_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    NICKNAME_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+    PHONE_UMBER_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 전화번호 입니다."),
+
     // 서버 에러
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 서버 팀으로 연락주시기 바랍니다.");

--- a/src/main/java/with_yu/common/response/success/SuccessRes.java
+++ b/src/main/java/with_yu/common/response/success/SuccessRes.java
@@ -1,20 +1,50 @@
 package with_yu.common.response.success;
 
-public record SuccessRes<T>(
-        int status,
-        String message,
-        T data
-) {
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+public class SuccessRes<T> {
+
+    private int status;
+    private String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    @Builder
+    private SuccessRes(int status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
     public static SuccessRes<?> from(SuccessType success){
-        return new SuccessRes<>(success.getStatusCode(), success.getMessage(), null);
+        return SuccessRes.builder()
+                .status(success.getStatusCode())
+                .message(success.getMessage())
+                .build();
     }
 
     public static <T> SuccessRes<?> from(T data){
-        return new SuccessRes<>(SuccessType.OK.getStatusCode(), SuccessType.OK.getMessage(), data);
+        return SuccessRes.builder()
+                .status(SuccessType.OK.getStatusCode())
+                .message(SuccessType.OK.getMessage())
+                .data(data)
+                .build();
     }
 
     public static <T> SuccessRes<?> from(SuccessType success, T data){
-        return new SuccessRes<>(success.getStatusCode(), success.getMessage(), data);
+        return SuccessRes.builder()
+                .status(success.getStatusCode())
+                .message(success.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static SuccessRes<?> ok(){
+        return SuccessRes.builder()
+                .status(SuccessType.OK.getStatusCode())
+                .message(SuccessType.OK.getMessage())
+                .build();
     }
 
 }

--- a/src/main/java/with_yu/common/response/success/SuccessRes.java
+++ b/src/main/java/with_yu/common/response/success/SuccessRes.java
@@ -2,7 +2,9 @@ package with_yu.common.response.success;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class SuccessRes<T> {
 
     private int status;
@@ -32,7 +34,7 @@ public class SuccessRes<T> {
                 .build();
     }
 
-    public static <T> SuccessRes<?> from(SuccessType success, T data){
+    public static <T> SuccessRes<?> of(SuccessType success, T data){
         return SuccessRes.builder()
                 .status(success.getStatusCode())
                 .message(success.getMessage())

--- a/src/main/java/with_yu/common/response/success/SuccessType.java
+++ b/src/main/java/with_yu/common/response/success/SuccessType.java
@@ -14,7 +14,7 @@ public enum SuccessType {
 
     // 201
     CREATED(HttpStatus.CREATED, "등록을 성공하였습니다."),
-    USER_CREATED(HttpStatus.CREATED, "등록을 성공하였습니다."),
+    USER_CREATED(HttpStatus.CREATED, "회원가입에 성공하였습니다."),
     CARPOOL_CREATED(HttpStatus.CREATED, "카풀 등록을 성공하였습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/with_yu/config/SecurityAuthConfig.java
+++ b/src/main/java/with_yu/config/SecurityAuthConfig.java
@@ -1,0 +1,19 @@
+package with_yu.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityAuthConfig {
+
+    @Bean
+    public PasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/with_yu/config/WebSecurityConfig.java
+++ b/src/main/java/with_yu/config/WebSecurityConfig.java
@@ -1,0 +1,30 @@
+package with_yu.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    private static final String[] PUBLIC_ENDPOINT = {"/**"};
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorizeHttpRequests ->
+                        authorizeHttpRequests.anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/with_yu/config/WebSecurityConfig.java
+++ b/src/main/java/with_yu/config/WebSecurityConfig.java
@@ -12,7 +12,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class WebSecurityConfig {
 
-    private static final String[] PUBLIC_ENDPOINT = {"/**"};
+    private static final String[] PUBLIC_ENDPOINT = {"/**", "/v1/auth/**"};
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/with_yu/domain/auth/controller/AuthController.java
+++ b/src/main/java/with_yu/domain/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package with_yu.domain.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import with_yu.common.response.success.SuccessRes;
+import with_yu.common.response.success.SuccessType;
+import with_yu.domain.auth.dto.SignupReq;
+import with_yu.domain.auth.service.AuthService;
+
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<?> signUp(@RequestBody SignupReq.General req){
+        authService.signUp(req);
+        return ResponseEntity.status(SuccessType.USER_CREATED.getStatus())
+                .body(SuccessRes.from(SuccessType.USER_CREATED));
+    }
+
+}

--- a/src/main/java/with_yu/domain/auth/dto/SignupReq.java
+++ b/src/main/java/with_yu/domain/auth/dto/SignupReq.java
@@ -1,0 +1,49 @@
+package with_yu.domain.auth.dto;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import with_yu.domain.user.entity.Role;
+import with_yu.domain.user.entity.User;
+
+public class SignupReq {
+
+    public record General(
+            String name,
+            String nickname,
+            String email,
+            String password,
+            String department,
+            String phoneNumber,
+            int studentNumber
+    ) {
+        public User toEntity(PasswordEncoder passwordEncoder) {
+            return User.builder()
+                    .name(name)
+                    .nickname(nickname)
+                    .email(email)
+                    .password(passwordEncoder.encode(password))
+                    .department(department)
+                    .phoneNumber(phoneNumber)
+                    .studentNumber(studentNumber)
+                    .role(Role.USER)
+                    .build();
+        }
+    }
+
+   /* 미사용
+   @Builder
+    public record SignupCheckInfo(
+            String nickname,
+            String email,
+            String phoneNumber,
+            int studentNumber
+    ){
+        public SignupCheckInfo from(SignupReq.General general) {
+            return SignupCheckInfo.builder()
+                    .nickname(general.nickname())
+                    .email(general.email())
+                    .phoneNumber(general.phoneNumber())
+                    .studentNumber(studentNumber())
+                    .build();
+        }
+    }*/
+}

--- a/src/main/java/with_yu/domain/auth/service/AuthService.java
+++ b/src/main/java/with_yu/domain/auth/service/AuthService.java
@@ -1,0 +1,34 @@
+package with_yu.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import with_yu.common.exception.CustomException;
+import with_yu.common.response.error.ErrorType;
+import with_yu.domain.auth.dto.SignupReq;
+import with_yu.domain.user.repository.UserRepository;
+import with_yu.domain.user.service.UserService;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserService userService;
+    private final PasswordEncoder bCryptPasswordEncoder;
+
+    @Transactional
+    public void signUp(SignupReq.General request){
+        if(!isAllowedSignup(request))
+            throw new CustomException(ErrorType.USER_ALREADY_EXIST);
+
+        userService.createUser(request.toEntity(bCryptPasswordEncoder));
+    }
+
+    @Transactional(readOnly = true)
+    protected boolean isAllowedSignup(SignupReq.General request){
+        return !userService.isExistNickname(request.nickname())
+                && !userService.isExitsByEmail(request.email())
+                && !userService.isExistPhoneNumber(request.phoneNumber());
+    }
+}

--- a/src/main/java/with_yu/domain/user/entity/Role.java
+++ b/src/main/java/with_yu/domain/user/entity/Role.java
@@ -1,0 +1,16 @@
+package with_yu.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("ROLE_USER"),
+    GUEST("ROLE_GUEST"),
+    ADMIN("ROLE_ADMIN"),
+    SUPERADMIN("ROLE_SUPERADMIN,ROLE_ADMIN,ROLE_GUEST,ROLE_USER")
+    ;
+
+    private final String value;
+}

--- a/src/main/java/with_yu/domain/user/entity/User.java
+++ b/src/main/java/with_yu/domain/user/entity/User.java
@@ -1,0 +1,48 @@
+package with_yu.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class User{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    private String name;
+    private String nickname;
+    private String email;
+    private String password;
+    private String department;
+    private String phoneNumber;
+    private int studentNumber;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Builder
+    public User(String name, String nickname, String email, String password, String department, String phoneNumber, int studentNumber, Role role) {
+        this.name = name;
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.department = department;
+        this.phoneNumber = phoneNumber;
+        this.studentNumber = studentNumber;
+        this.role = Role.USER;
+    }
+
+    // Provider
+    // 차량
+    // 받은 리뷰
+    // 남긴 리뷰
+    // 제공 카풀
+    // 받은 카풀
+
+}

--- a/src/main/java/with_yu/domain/user/repository/UserRepository.java
+++ b/src/main/java/with_yu/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package with_yu.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import with_yu.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    boolean existsByPhoneNumber(String phoneNumber);
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/with_yu/domain/user/service/UserService.java
+++ b/src/main/java/with_yu/domain/user/service/UserService.java
@@ -1,0 +1,34 @@
+package with_yu.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import with_yu.domain.user.entity.User;
+import with_yu.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User createUser(User user) {
+        return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isExistNickname(String nickname){
+        return userRepository.existsByNickname(nickname);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isExistPhoneNumber(String phoneNumber){
+        return userRepository.existsByPhoneNumber(phoneNumber);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isExitsByEmail(String email){
+        return userRepository.existsByEmail(email);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?serverTimezone=Asia/Seoul
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
+    url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT:3306}/${DATABASE_NAME:withyu}?serverTimezone=Asia/Seoul
+    username: ${DATABASE_USERNAME:root}
+    password: ${DATABASE_PASSWORD:password}
   jpa:
     hibernate:
       ddl-auto: update
@@ -12,10 +12,17 @@ spring:
     show-sql: true
     properties:
       hibernate:
-
         format_sql: true
         default_batch_fetch_size: 1000
         dialect: org.hibernate.dialect.MySQLDialect
         jdbc:
           time_zone: Asia/Seoul
 
+--- # redis
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      repositories:
+        enabled: false


### PR DESCRIPTION
## 🛠 작업 동기
- User Entity(base info) : 원래는 모든 엔티티를 한 번에 개발하려했지만, 한 엔티티씩 개발하는 것이 좋아보여 User Entity를 만들기로 하였습니다.
- 회원가입 api

## 📌 추가 및 변경사항
- 회원가입 로직 추가
   - `AuthService`와 `UserService`를 나누어, 책임을 조금 더 세분화하여 나누었습니다.
   - `AuthService`가 `UserSerivce`를 주입받아 동작하는 구조입니다.

## ✔ 테스트 결과

![image](https://github.com/user-attachments/assets/8bd37f73-4631-4ce8-a003-0b875e05e139)

### 성공
![image](https://github.com/user-attachments/assets/61f26fdc-1c82-410b-bb63-f3cd88b1992f)

### 실패
![image](https://github.com/user-attachments/assets/da9dc11b-d974-43aa-bbc1-0bad902f0093)

## ✨ 기타
- 회원가입 전 닉네임, 전화번호, 이메일에 관한 중복 여부를 확인 로직이 따로 있을 예정이기에, 회원가입 로직에서 에러 발생 시에는 `USER_ALREADY_EXIST` 에러 발생
- 차후, 회원가입 후 바로 토큰 지급하는 로직 추가 고려