### PR TITLE
Redis 추가 및 로그인 시 리프레시 토큰 Redis 저장

### DIFF
--- a/src/main/java/with_yu/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/with_yu/common/exception/GlobalExceptionHandler.java
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler
     protected ResponseEntity<?> handleException(final Exception e) {
         ErrorRes error = new ErrorRes(INTERNAL_SERVER_ERROR.getStatusCode(), INTERNAL_SERVER_ERROR.getMessage());
-        log.error("Error occured : [errorCode={}, message={}, Stack Trace={}]",e.getClass(), e.getMessage(), getStackTrace(e));
+        log.error("Error occured : [errorCode={}, message={}]\n<<Stack Trace 5 lines>>\n{}",e.getClass(), e.getMessage(), getStackTrace(e));
         return ResponseEntity.status(error.status()).body(error);
     }
 

--- a/src/main/java/with_yu/common/util/JwtUtil.java
+++ b/src/main/java/with_yu/common/util/JwtUtil.java
@@ -2,6 +2,7 @@ package with_yu.common.util;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import with_yu.domain.user.entity.Role;
@@ -47,6 +48,14 @@ public class JwtUtil {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
+    }
+
+    public String getSubject(String token){
+        return this.parseToken(token).getSubject();
+    }
+
+    public long getRefreshTokenExpiration(){
+        return this.refreshTokenExpiration.toMillis();
     }
 
 

--- a/src/main/java/with_yu/common/util/RedisProperties.java
+++ b/src/main/java/with_yu/common/util/RedisProperties.java
@@ -1,0 +1,6 @@
+package with_yu.common.util;
+
+public interface RedisProperties {
+    String REFRESH_TOKEN_PREFIX = "refresh-token::";
+    String BLACKLIST_TOKEN_PREFIX = "blacklist-token::";
+}

--- a/src/main/java/with_yu/common/util/RedisUtil.java
+++ b/src/main/java/with_yu/common/util/RedisUtil.java
@@ -1,0 +1,31 @@
+package with_yu.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Component
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void save(String key, Object value, long expiration) {
+        redisTemplate.opsForValue().set(key, value, expiration, TimeUnit.MILLISECONDS);
+    }
+
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public boolean exists(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+}

--- a/src/main/java/with_yu/config/RedisConfig.java
+++ b/src/main/java/with_yu/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package with_yu.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+
+        if (!password.isBlank()) {
+            System.out.println("is not blank");
+            redisStandaloneConfiguration.setPassword(password);
+        }
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+
+
+}

--- a/src/main/java/with_yu/domain/auth/service/AuthService.java
+++ b/src/main/java/with_yu/domain/auth/service/AuthService.java
@@ -7,6 +7,8 @@ import with_yu.common.exception.CustomException;
 import with_yu.common.response.error.ErrorType;
 import with_yu.common.util.JwtUtil;
 import with_yu.common.util.PasswordEncoderHelper;
+import with_yu.common.util.RedisProperties;
+import with_yu.common.util.RedisUtil;
 import with_yu.domain.auth.dto.JwtTokenDto;
 import with_yu.domain.auth.dto.LoginReq;
 import with_yu.domain.auth.dto.SignupReq;
@@ -20,6 +22,7 @@ public class AuthService {
     private final UserService userService;
     private final PasswordEncoderHelper passwordEncoderHelper;
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
 
     @Transactional
     public void signUp(SignupReq.General request){
@@ -39,6 +42,9 @@ public class AuthService {
 
         String accessToken = jwtUtil.generateAccessToken(user.getEmail(), user.getRole());
         String refreshToken = jwtUtil.generateRefreshToken(user.getEmail(), user.getRole());
+
+        String key = RedisProperties.REFRESH_TOKEN_PREFIX + user.getEmail();
+        redisUtil.save(key, refreshToken, jwtUtil.getRefreshTokenExpiration());
 
         return JwtTokenDto.of(accessToken, refreshToken);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
       repositories:
         enabled: false
 


### PR DESCRIPTION
## 🛠 작업 동기
- #14 

## 📌 추가 및 변경사항
- Redis 추가
- 로그인 시 리프레시 토큰을 Redis에 저장 - key : `refresh-token::{USER_EMAIL}`

## ✔ 테스트 결과
![image](https://github.com/user-attachments/assets/3e750232-00f4-4066-8fcc-3f7c5a7413dd)

