### PR TITLE
이메일 인증 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/with_yu/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/with_yu/common/exception/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<?> handleCustomException(final CustomException e) {
         ErrorType error = e.getErrorType();
-        log.error("Error occured : [errorCode={}, message={}]", error.getStatusCode(), error.getMessage());
+        log.error("Error occurred : [errorCode={}, message={}]", error.getStatusCode(), error.getMessage());
         return ResponseEntity.status(error.getStatus()).body(ErrorRes.of(error.getStatusCode(),error.getMessage()));
     }
 
@@ -33,7 +33,7 @@ public class GlobalExceptionHandler {
         for(FieldError fieldError : e.getBindingResult().getFieldErrors() ){
             body.put(fieldError.getField(), fieldError.getDefaultMessage());
         }
-        log.error("Error occured : [message={}]",body);
+        log.error("Error occurred : [message={}]",body);
         return ResponseEntity.status(ErrorType.BAD_REQUEST.getStatus()).body(body);
     }
 
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler
     protected ResponseEntity<?> handleException(final Exception e) {
         ErrorRes error = new ErrorRes(INTERNAL_SERVER_ERROR.getStatusCode(), INTERNAL_SERVER_ERROR.getMessage());
-        log.error("Error occured : [errorCode={}, message={}]\n<<Stack Trace 5 lines>>\n{}",e.getClass(), e.getMessage(), getStackTrace(e));
+        log.error("Error occurred : [errorCode={}, message={}]\n<<Stack Trace 5 lines>>\n{}",e.getClass(), e.getMessage(), getStackTrace(e));
         return ResponseEntity.status(error.status()).body(error);
     }
 

--- a/src/main/java/with_yu/common/response/error/ErrorType.java
+++ b/src/main/java/with_yu/common/response/error/ErrorType.java
@@ -11,6 +11,7 @@ public enum ErrorType {
     // 400
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효성 검증 실패. 잘못된 요청입니다."),
     MAIL_SEND_FAILED(HttpStatus.BAD_REQUEST, "이메일 발송에 실패하였습니다."),
+    WRONG_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 코드입니다."),
 
 
     // 401
@@ -36,6 +37,10 @@ public enum ErrorType {
     EMAIL_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     NICKNAME_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     PHONE_UMBER_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용 중인 전화번호 입니다."),
+
+    // gone
+    // 410
+    VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, "이메일 코드 인증 시간이 만료되었습니다."),
 
     // 서버 에러
     // 500

--- a/src/main/java/with_yu/common/response/error/ErrorType.java
+++ b/src/main/java/with_yu/common/response/error/ErrorType.java
@@ -8,6 +8,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorType {
 
+    // 400
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효성 검증 실패. 잘못된 요청입니다."),
+    MAIL_SEND_FAILED(HttpStatus.BAD_REQUEST, "이메일 발송에 실패하였습니다."),
+
+
     // 401
     UN_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
@@ -18,10 +23,6 @@ public enum ErrorType {
     // 인가
     // 403
     UN_AUTHORIZATION(HttpStatus.FORBIDDEN, "허용되지 않은 접근입니다."),
-
-    // 검증
-    // 400
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효성 검증 실패. 잘못된 요청입니다."),
 
     // 데이터
     // 404

--- a/src/main/java/with_yu/common/response/success/SuccessType.java
+++ b/src/main/java/with_yu/common/response/success/SuccessType.java
@@ -10,8 +10,10 @@ public enum SuccessType {
 
     // 200
     OK(HttpStatus.OK, "요청이 정상적으로 완료되었습니다."),
+    MAIL_SEND_SUCCESS(HttpStatus.OK, "메일 전송이 완료되었습니다."),
     REGISTRATION_SUCCESS(HttpStatus.OK, "카풀 신청에 성공하였습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
+    VERIFY_CODE_SUCCESS(HttpStatus.OK, "이메일 인증에 성공하였습니다."),
 
     // 201
     CREATED(HttpStatus.CREATED, "등록을 성공하였습니다."),

--- a/src/main/java/with_yu/common/util/MailProperties.java
+++ b/src/main/java/with_yu/common/util/MailProperties.java
@@ -1,0 +1,6 @@
+package with_yu.common.util;
+
+
+public interface MailProperties {
+    String CODE_MAIL_SUBJECT = "[withyu] 이메일 인증 코드 발급";
+}

--- a/src/main/java/with_yu/common/util/RedisProperties.java
+++ b/src/main/java/with_yu/common/util/RedisProperties.java
@@ -3,4 +3,5 @@ package with_yu.common.util;
 public interface RedisProperties {
     String REFRESH_TOKEN_PREFIX = "refresh-token::";
     String BLACKLIST_TOKEN_PREFIX = "blacklist-token::";
+    String CODE_PREFIX = "code::";
 }

--- a/src/main/java/with_yu/common/util/RedisProperties.java
+++ b/src/main/java/with_yu/common/util/RedisProperties.java
@@ -4,4 +4,5 @@ public interface RedisProperties {
     String REFRESH_TOKEN_PREFIX = "refresh-token::";
     String BLACKLIST_TOKEN_PREFIX = "blacklist-token::";
     String CODE_PREFIX = "code::";
+    Long CODE_EXPIRATION = 180000L;
 }

--- a/src/main/java/with_yu/config/AsyncConfig.java
+++ b/src/main/java/with_yu/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package with_yu.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/with_yu/config/MailConfig.java
+++ b/src/main/java/with_yu/config/MailConfig.java
@@ -11,7 +11,7 @@ import java.util.Properties;
 @Configuration
 public class MailConfig {
 
-    @Value("${mail.username}") private String username;
+    @Value("${mail.admin-mail}") private String username;
     @Value("${mail.password}") private String password;
     @Value("${mail.host}") private String host;
     @Value("${mail.port}") private int port;

--- a/src/main/java/with_yu/config/MailConfig.java
+++ b/src/main/java/with_yu/config/MailConfig.java
@@ -1,0 +1,44 @@
+package with_yu.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${mail.username}") private String username;
+    @Value("${mail.password}") private String password;
+    @Value("${mail.host}") private String host;
+    @Value("${mail.port}") private int port;
+
+    @Bean
+    public JavaMailSender getJavaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties javaMailProperties =  new Properties();
+        javaMailProperties.put("mail.transport.protocol", "smtp");
+        javaMailProperties.put("mail.smtp.auth", "true");
+        javaMailProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+        javaMailProperties.put("mail.smtp.starttls.enable", "true");
+        javaMailProperties.put("mail.debug", "false");
+        javaMailProperties.put("mail.smtp.ssl.trust", host);
+        javaMailProperties.put("mail.smtp.ssl.protocols", "TLSv1.3");
+
+        mailSender.setJavaMailProperties(javaMailProperties);
+
+        return mailSender;
+    }
+
+    public String getSender(){
+        return username;
+    }
+}

--- a/src/main/java/with_yu/config/ThymeleafConfig.java
+++ b/src/main/java/with_yu/config/ThymeleafConfig.java
@@ -1,0 +1,28 @@
+package with_yu.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+@Configuration
+public class ThymeleafConfig {
+
+    @Bean
+    public ClassLoaderTemplateResolver templateResolver() {
+        ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+        templateResolver.setPrefix("/templates/");
+        templateResolver.setSuffix(".html");
+        templateResolver.setTemplateMode("HTML");
+        templateResolver.setCharacterEncoding("UTF-8");
+        templateResolver.setOrder(1);
+        return templateResolver;
+    }
+
+    @Bean
+    public SpringTemplateEngine templateEngine() {
+        SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.setTemplateResolver(templateResolver());
+        return templateEngine;
+    }
+}

--- a/src/main/java/with_yu/domain/mail/controller/MailController.java
+++ b/src/main/java/with_yu/domain/mail/controller/MailController.java
@@ -1,0 +1,35 @@
+package with_yu.domain.mail.controller;
+
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import with_yu.common.exception.CustomException;
+import with_yu.common.response.error.ErrorType;
+import with_yu.domain.mail.service.MailService;
+
+@Controller
+@RequestMapping("/v1/mail/")
+@RequiredArgsConstructor
+@Slf4j
+public class MailController {
+
+    private final MailService mailService;
+
+    @PostMapping("/email-verification")
+    public ResponseEntity<?> emailVerification(@RequestParam("email") String email) {
+        try{
+            mailService.sendMail(email);
+        } catch(Exception e) {
+            log.error("Failed to send email. error = {}, message={}", e.getClass(), e.getMessage());
+            throw new CustomException(ErrorType.MAIL_SEND_FAILED);
+        }
+
+        return ResponseEntity.ok().body(null);
+    }
+
+}

--- a/src/main/java/with_yu/domain/mail/controller/MailController.java
+++ b/src/main/java/with_yu/domain/mail/controller/MailController.java
@@ -5,11 +5,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import with_yu.common.exception.CustomException;
 import with_yu.common.response.error.ErrorType;
+import with_yu.common.response.success.SuccessRes;
+import with_yu.common.response.success.SuccessType;
 import with_yu.domain.mail.service.MailService;
 
 @Controller
@@ -20,7 +23,7 @@ public class MailController {
 
     private final MailService mailService;
 
-    @PostMapping("/email-verification")
+    @GetMapping("/email-verification")
     public ResponseEntity<?> emailVerification(@RequestParam("email") String email) {
         try{
             mailService.sendMail(email);
@@ -29,7 +32,9 @@ public class MailController {
             throw new CustomException(ErrorType.MAIL_SEND_FAILED);
         }
 
-        return ResponseEntity.ok().body(null);
+        return ResponseEntity.status(SuccessType.MAIL_SEND_SUCCESS.getStatus())
+                .body(SuccessRes.from(SuccessType.MAIL_SEND_SUCCESS));
     }
+
 
 }

--- a/src/main/java/with_yu/domain/mail/controller/MailController.java
+++ b/src/main/java/with_yu/domain/mail/controller/MailController.java
@@ -5,14 +5,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import with_yu.common.exception.CustomException;
 import with_yu.common.response.error.ErrorType;
 import with_yu.common.response.success.SuccessRes;
 import with_yu.common.response.success.SuccessType;
+import with_yu.domain.mail.dto.CodeVerificationReq;
 import with_yu.domain.mail.service.MailService;
 
 @Controller
@@ -36,5 +34,11 @@ public class MailController {
                 .body(SuccessRes.from(SuccessType.MAIL_SEND_SUCCESS));
     }
 
+    @PostMapping("/email-verification")
+    public ResponseEntity<?> codeVerification(@RequestBody CodeVerificationReq req){
+        mailService.verifyCode(req);
+        return ResponseEntity.status(SuccessType.VERIFY_CODE_SUCCESS.getStatus())
+                .body(SuccessRes.from(SuccessType.VERIFY_CODE_SUCCESS));
+    }
 
 }

--- a/src/main/java/with_yu/domain/mail/dto/CodeVerificationReq.java
+++ b/src/main/java/with_yu/domain/mail/dto/CodeVerificationReq.java
@@ -1,0 +1,7 @@
+package with_yu.domain.mail.dto;
+
+public record CodeVerificationReq(
+        String email,
+        String code
+) {
+}

--- a/src/main/java/with_yu/domain/mail/service/MailService.java
+++ b/src/main/java/with_yu/domain/mail/service/MailService.java
@@ -1,0 +1,57 @@
+package with_yu.domain.mail.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import with_yu.common.util.MailProperties;
+import with_yu.config.MailConfig;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private final MailConfig mailConfig;
+    private final SpringTemplateEngine templateEngine;
+
+    @Async
+    public void sendMail(String email) throws MessagingException {
+        try {
+
+
+            MimeMessage mimeMailMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMailMessage, true, "utf-8");
+            mimeMessageHelper.setFrom(mailConfig.getSender());
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject(MailProperties.CODE_MAIL_SUBJECT);
+
+            Context context = new Context();
+            String code = createRandomCode();
+            context.setVariable("code", code);
+            String html = templateEngine.process("mail", context);
+            mimeMessageHelper.setText(html, true);
+
+            javaMailSender.send(mimeMailMessage);
+            
+            // redis 도입 필요
+        } catch (MessagingException e) {
+            throw e; // rethrown
+        }
+
+    }
+
+    private String createRandomCode(){
+        Random rand = new Random();
+
+        return String.valueOf(rand.nextInt(999999));
+    }
+
+}

--- a/src/main/java/with_yu/domain/mail/service/MailService.java
+++ b/src/main/java/with_yu/domain/mail/service/MailService.java
@@ -1,16 +1,21 @@
 package with_yu.domain.mail.service;
 
-import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
+import with_yu.common.exception.CustomException;
+import with_yu.common.response.error.ErrorType;
 import with_yu.common.util.MailProperties;
+import with_yu.common.util.RedisProperties;
+import with_yu.common.util.RedisUtil;
 import with_yu.config.MailConfig;
+import with_yu.domain.mail.dto.CodeVerificationReq;
 
 import java.util.Random;
 
@@ -21,12 +26,13 @@ public class MailService {
     private final JavaMailSender javaMailSender;
     private final MailConfig mailConfig;
     private final SpringTemplateEngine templateEngine;
+    private final RedisUtil redisUtil;
 
     @Async
     public void sendMail(String email) throws Exception {
 
             MimeMessage mimeMailMessage = javaMailSender.createMimeMessage();
-            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMailMessage, true, "utf-8");
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMailMessage, false, "utf-8");
             mimeMessageHelper.setFrom(mailConfig.getSender());
             mimeMessageHelper.setTo(email);
             mimeMessageHelper.setSubject(MailProperties.CODE_MAIL_SUBJECT);
@@ -39,7 +45,27 @@ public class MailService {
 
             javaMailSender.send(mimeMailMessage);
             
-            // redis 도입 필요
+            String key = RedisProperties.CODE_PREFIX + email;
+            redisUtil.save(key, code, RedisProperties.CODE_EXPIRATION);
+    }
+
+    @Transactional
+    public void verifyCode(CodeVerificationReq req){
+        String key = RedisProperties.CODE_PREFIX + req.email();
+        if(!redisUtil.exists(key))
+            throw new CustomException(ErrorType.VERIFICATION_CODE_EXPIRED);
+
+        String code = (String) redisUtil.get(key);
+
+        if(!isValidCode(req.code(), code))
+            throw new CustomException(ErrorType.WRONG_CODE);
+        else{
+            redisUtil.delete(key);
+        }
+    }
+
+    private boolean isValidCode(String actual, String expected){
+        return actual.equals(expected);
     }
 
     private String createRandomCode(){

--- a/src/main/java/with_yu/domain/mail/service/MailService.java
+++ b/src/main/java/with_yu/domain/mail/service/MailService.java
@@ -23,9 +23,7 @@ public class MailService {
     private final SpringTemplateEngine templateEngine;
 
     @Async
-    public void sendMail(String email) throws MessagingException {
-        try {
-
+    public void sendMail(String email) throws Exception {
 
             MimeMessage mimeMailMessage = javaMailSender.createMimeMessage();
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMailMessage, true, "utf-8");
@@ -42,10 +40,6 @@ public class MailService {
             javaMailSender.send(mimeMailMessage);
             
             // redis 도입 필요
-        } catch (MessagingException e) {
-            throw e; // rethrown
-        }
-
     }
 
     private String createRandomCode(){

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,5 +40,5 @@ jwt:
 mail:
   host: smtp.gmail.com
   port: 587
-  username: ${ADMIN_EMAIL:admin@withyu.com}
+  admin-mail: ${ADMIN_EMAIL:admin@withyu.com}
   password: ${ADMIN_EMAIL_APP_PASSWORD:password}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,10 @@ jwt:
     access-token: ${JWT_ACCESS_TOKEN_EXPIRATION:1209600000}
     refresh-token: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600000}
   issuer: ${JWT_ISSUER:withyu}
+
+--- # mail
+mail:
+  host: smtp.gmail.com
+  port: 587
+  username: ${ADMIN_EMAIL:admin@withyu.com}
+  password: ${ADMIN_EMAIL_APP_PASSWORD:password}

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body style="font-family: Arial, sans-serif; margin: 0; padding: 20px; background-color: #f4f4f4; ">
+<h1 style="background-color: #333; color: white; padding: 20px; text-align: center; border-radius: 5px 5px 0 0; margin: 0; font-size: 28px;">
+    withyu
+</h1>
+<div style="background: white; padding: 20px; border-radius: 0 0 5px 5px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);">
+    <h2 style="margin: 0;">안녕하세요!</h2>
+    <p style="color: #555; line-height: 1.6;">
+        요청하신 인증번호는 아래와 같습니다.
+    </p>
+    <p th:text="${code}" style="margin: 20px 0; font-size: 30px; font-weight: 600"></p>
+    <p style="color: #555; line-height: 1.6;">
+        위의 인증번호를 3분 안에 입력하여 주시길 바랍니다.
+    </p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 🛠 작업 동기
- #16 

## 📌 추가 및 변경사항
- 이메일 인증 코드 발급 - `GET/v1/mail/verification?email=`
   - 이메일 인증 코드 발급 후 만료 기한 3분, 만료 시 Redis 내에서 삭제
   - 랜덤 6자리 발급
- 이메일 인증 - `POST/v1/mail/verification`

## ✔ 테스트 결과



### 1. 코드 발급
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/25ab07e9-ef6c-4c9f-ba68-b6e1e5acf2f9">


<img width="1156" alt="image" src="https://github.com/user-attachments/assets/d9c9aac4-c1a0-4814-a496-13a94073892e">

### 2. 코드 인증

#### 성공
<img width="1019" alt="image" src="https://github.com/user-attachments/assets/5bdf0c21-bc7b-4068-92de-8c6014d5d7bc">

#### 실패

<img width="1001" alt="image" src="https://github.com/user-attachments/assets/f58cd23d-4fc7-4a6f-819f-2fc5119ed8e2">

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/9c238d8a-dd2f-4f79-bc33-7c08a99fc723">


## ✨ 기타
- 현재 MailService에 코드 발급, 코드 검증 로직이 같이 있다. 나중에 추가 MailService 개발 시 CodeService 클래스 생성 및 Strategy 패턴 적용 필요
